### PR TITLE
Update index.rst to remove circular link

### DIFF
--- a/docs/public/index.rst
+++ b/docs/public/index.rst
@@ -24,10 +24,4 @@ For a quick start, follow :doc:`installation<installation>` steps, and then look
    backend/op
    developer
 
-Index
-=====
-
-* :ref:`genindex`
-
-
 .. |tm|   unicode:: U+02122 .. TM SIGN


### PR DESCRIPTION
The link at the bottom of the index page just refreshes the page. It is not going anywhere and could be confusing to a user. It does not seem necessary to have here.